### PR TITLE
Fix for Laravel 5.1

### DIFF
--- a/src/Caffeinated/Themes/Components.php
+++ b/src/Caffeinated/Themes/Components.php
@@ -68,12 +68,8 @@ class Components
 	 */
 	protected function registerTag($method, $namespace = '')
 	{
-		$this->blade->extend(function($view, $compiler) use ($method, $namespace) {
-			$pattern = $compiler->createMatcher('component_'.$method);
-
-			$replace = '$1<?php echo '.$namespace.$method.'$2; ?>';
-
-			return preg_replace($pattern, $replace, $view);
+		$this->blade->directive('component_'.$method, function($view) use ($method,$namespace){
+			return '<?php echo '.$namespace.$method."$view; ?>";
 		});
 	}
 


### PR DESCRIPTION
As mentioned in the Upgrade Guide the createMatcher, createOpenMatcher, and createPlainMatcher methods have been removed from the Blade compiler in Laravel 5.1. 

Using the Components with Laravel 5.1 thorws an error stating that Blade::createMatcher cannot be called. 

To fix this it is migrated to Blade::directive().