### PR TITLE
"bindshared" to "singleton" for Laravel 5.2

### DIFF
--- a/src/ThemesServiceProvider.php
+++ b/src/ThemesServiceProvider.php
@@ -57,13 +57,13 @@ class ThemesServiceProvider extends ServiceProvider {
 	 */
 	protected function registerServices()
 	{
-		$this->app->bindShared('themes.components', function($app) {
+		$this->app->singleton('themes.components', function($app) {
 			$blade = $app['view']->getEngineResolver()->resolve('blade')->getCompiler();
 
 			return new Components($app, $blade);
 		});
 
-		$this->app->bindShared('themes', function($app) {
+		$this->app->singleton('themes', function($app) {
 			return new Themes($app['files'], $app['config'], $app['view']);
 		});
 


### PR DESCRIPTION
```php
$this->app->bindShared('
```
to
```php
$this->app->singleton('
```
and even works on 5.1