### PR TITLE
Update Themes.php

### DIFF
--- a/src/Themes.php
+++ b/src/Themes.php
@@ -375,10 +375,10 @@ class Themes
 			$asset = $segments[0];
 		}
 
-		return url().'/'.$this->config->get('themes.paths.base').'/'
+		return url($this->config->get('themes.paths.base').'/'
 			.($theme ?: $this->getActive()).'/'
 			.$this->config->get('themes.paths.assets').'/'
-			.$asset;
+			.$asset);
 	}
 
 	/**


### PR DESCRIPTION
Fixed for "`Object of class Illuminate\Routing\UrlGenerator could not be converted to string`" error. (on Laravel 5.2)