### PR TITLE
Fixed service registration so it won't break when no 'themes' folder yet exists.

### DIFF
--- a/src/ThemesServiceProvider.php
+++ b/src/ThemesServiceProvider.php
@@ -59,29 +59,35 @@ class ThemesServiceProvider extends ServiceProvider
 	protected function registerServices()
 	{
 		$this->app->singleton('caffeinated.themes', function($app) {
-            $themes = $this->app['files']->directories(config('themes.paths.absolute'));
-            
+            $themes = [];
+            $items  = [];
+
+            if ($path = config('themes.paths.absolute')) {
+                if (file_exists($path) && is_dir($path)) {
+                    $themes = $this->app['files']->directories($path);
+                }
+            }
+
             foreach ($themes as $theme) {
                 $manifest = new Manifest($theme.'/theme.json');
-                
                 $items[] = $manifest;
             }
-            
-			return new Theme($items);
+
+            return new Theme($items);
 		});
-        
+
         $this->app->singleton('view.finder', function($app) {
             return new ThemeViewFinder($app['files'], $app['config']['view.paths'], null);
         });
 	}
-    
+
     /**
      * Register the theme namespaces.
      */
     protected function registerNamespaces()
     {
         $themes = app('caffeinated.themes')->all();
-        
+
         foreach ($themes as $theme) {
             app('view')->addNamespace($theme->get('slug'), app('caffeinated.themes')->getAbsolutePath($theme->get('slug')).'/views');
         }


### PR DESCRIPTION
This handles the situation when config('themes.paths.absolute') returns either null or the returned path does not yet exist. Previously this situation would break the traversing of the themes root folder, in search of theme subfolders, which would throw a "must call one of in() or append() methods before iterating over a Finder" FileSystem exception. 